### PR TITLE
[Update] (vscode): 修改clangd设置以优化编译器路径

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,18 +7,12 @@
     "C_Cpp.intelliSenseEngine": "disabled",
     "clangd.arguments": [
         "--clang-tidy",
-        // compelie_commands.json 文件的目录位置(相对于工作区，由于 CMake 生成的该文件默认在 build 文件夹中，故设置为 build)
         "--compile-commands-dir=./build",
-        // 让 Clangd 生成更详细的日志
         "--log=verbose",
-        // 输出的 JSON 文件更美观
         "--pretty",
-        // 建议排序模型
         "--ranking-model=heuristics",
-        // 同时开启的任务数量
         "-j=12",
-        // 指定编译器的位置，必须使用带源文件头文件的编译器地址，不然会提示找不到头文件
-        "--query-driver=${env:ARM_TOOLCHAIN_CPP}"
+        "--query-driver=${env:ARM_CXX_PATH}"
     ],
     "todo-tree.tree.showBadges": false,
     "marscode.chatLanguage": "cn",

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ os:
 
 ### Ubuntu
 
+#### 安装依赖
+
 - Vscode
 1. `sudo snap install --classic code`
 
@@ -67,6 +69,12 @@ export PATH=$PATH:/home/gd32-dev/Documents/tools/LLVM-19.1.6-Linux-X64/bin:/home
 
 - openocd
 1. 需要[自行编译安装最新版的openocd](https://blog.csdn.net/qq_39765790/article/details/133470373)
+
+#### 配置vscode
+- 指定clangd的编译器
+1. 将`arm-none-eabi-g++`的地址定义为环境变量`ARM_CXX_PATH`
+2. `export ARM_CXX_PATH="/home/gd32-dev/Documents/tools/xpack-arm-none-eabi-gcc-14.2.1-1.1/bin/arm-none-eabi-g++"`
+3. reboot生效环境变量   
 
 ### MacOS
 


### PR DESCRIPTION
更新clangd的编译器查询参数，使用`ARM_CXX_PATH`环境变量替代`ARM_TOOLCHAIN_CPP`。

在readme中添加依赖安装和vscode配置步骤，以指导用户正确设置开发环境。

closes #34 