### PR TITLE
Master-modify

### DIFF
--- a/Source/BSP/inc/bsp_log.hpp
+++ b/Source/BSP/inc/bsp_log.hpp
@@ -16,10 +16,10 @@ extern "C" {
 #include "task.h"
 }
 
-#define LOG_QUEUE_SIZE 128
+// #define LOG_QUEUE_SIZE 128
 
 // 定义日志消息的最大长度
-#define LOG_MESSAGE_MAX_LENGTH 128
+#define LOG_QUEUE_SIZE 256
 
 // 定义日志队列的长度
 #define LOG_QUEUE_LENGTH 20
@@ -30,7 +30,7 @@ extern "C" {
 
 // 日志消息结构体
 struct LogMessage {
-    std::array<char, LOG_MESSAGE_MAX_LENGTH> message;
+    std::array<char, LOG_QUEUE_SIZE> message;
 };
 
 // 日志级别枚举
@@ -132,8 +132,8 @@ class Logger {
     void output(Level level, const char *message) {
         LogMessage logMsg;
         std::strncpy(logMsg.message.data(), message,
-                     LOG_MESSAGE_MAX_LENGTH - 1);
-        logMsg.message[LOG_MESSAGE_MAX_LENGTH - 1] = '\0';
+                     LOG_QUEUE_SIZE - 1);
+        logMsg.message[LOG_QUEUE_SIZE - 1] = '\0';
 
         // 将日志消息放入队列
         if (!logQueue.add(logMsg, portMAX_DELAY)) {

--- a/Source/Core/master/master_cfg.hpp
+++ b/Source/Core/master/master_cfg.hpp
@@ -4,9 +4,9 @@
 // system
 #define SLAVE_USE_UWB
 
-#define CONDUCTION_TEST_INTERVAL           5      // 导通检测时间间隔
+#define CONDUCTION_TEST_INTERVAL           20      // 导通检测时间间隔
 #define CLIP_TEST_INTERVAL                 20     // 卡钉检测时间间隔
-#define SYNC_TIMER_PERIOD_REDUNDANCY_TICKS 0    // 同步定时器冗余时间
+#define SYNC_TIMER_PERIOD_REDUNDANCY_TICKS 100    // 同步定时器冗余时间
 #define PC_TX_SHARE_MEM_ACCESS_TIMEOUT \
     1000    // 获取上位机数据传输共享内存写权限超时
 #define PC_TX_TIMEOUT 1000    // 向上位机发送数据超时

--- a/Source/Core/master/master_mode.cpp
+++ b/Source/Core/master/master_mode.cpp
@@ -67,27 +67,27 @@ static void Master_Task(void* pvParameters) {
     cfg.resistanceNum = 0;
     slave_cfg_msg.slaves.push_back(cfg);
     slave_cfg_msg.slaveNum = 2;
-    auto msg = PacketPacker::backendPack(slave_cfg_msg);
+    auto msg = PacketPacker::backend2MasterPack(slave_cfg_msg);
     std::vector<uint8_t> data = FramePacker::pack(msg);
     Log.r(data.data(), data.size());
 
     Log.i("[Master_Task]: Mode packet:");
     Backend2Master::ModeCfgMsg mode_msg;
     mode_msg.mode = 0x00;
-    msg = PacketPacker::backendPack(mode_msg);
+    msg = PacketPacker::backend2MasterPack(mode_msg);
     data = FramePacker::pack(msg);
     Log.r(data.data(), data.size());
 
     Log.i("[Master_Task]: Control start packet:");
     Backend2Master::CtrlMsg ctrl_msg;
     ctrl_msg.runningStatus = 0x01;
-    msg = PacketPacker::backendPack(ctrl_msg);
+    msg = PacketPacker::backend2MasterPack(ctrl_msg);
     data = FramePacker::pack(msg);
     Log.r(data.data(), data.size());
     
     Log.i("[Master_Task]: Control stop packet:");
     ctrl_msg.runningStatus = 0x00;
-    msg = PacketPacker::backendPack(ctrl_msg);
+    msg = PacketPacker::backend2MasterPack(ctrl_msg);
     data = FramePacker::pack(msg);
     Log.r(data.data(), data.size());
 

--- a/Source/Core/master/master_mode.cpp
+++ b/Source/Core/master/master_mode.cpp
@@ -51,45 +51,45 @@ static void Master_Task(void* pvParameters) {
     Log.i("Master_Task: Boot");
 
     Log.i("[Master_Task]: Cond packet:");
-    Backend2Master::SlaveCfgMsg slave_cfg_msg;
-    Backend2Master::SlaveCfgMsg::SlaveConfig cfg;
-    cfg.id = 0x12345678;
-    cfg.clipMode = 0x01;
-    cfg.clipStatus = 0x00;
-    cfg.conductionNum = 16;
-    cfg.resistanceNum = 0;
-    slave_cfg_msg.slaves.push_back(cfg);
+    // Backend2Master::SlaveCfgMsg slave_cfg_msg;
+    // Backend2Master::SlaveCfgMsg::SlaveConfig cfg;
+    // cfg.id = 0x12345678;
+    // cfg.clipMode = 0x01;
+    // cfg.clipStatus = 0x00;
+    // cfg.conductionNum = 16;
+    // cfg.resistanceNum = 0;
+    // slave_cfg_msg.slaves.push_back(cfg);
 
-    cfg.id = 0x11ABCDEF;
-    cfg.clipMode = 0x00;
-    cfg.clipStatus = 0x00;
-    cfg.conductionNum = 20;
-    cfg.resistanceNum = 0;
-    slave_cfg_msg.slaves.push_back(cfg);
-    slave_cfg_msg.slaveNum = 2;
-    auto msg = PacketPacker::backend2MasterPack(slave_cfg_msg);
-    std::vector<uint8_t> data = FramePacker::pack(msg);
-    Log.r(data.data(), data.size());
+    // cfg.id = 0x11ABCDEF;
+    // cfg.clipMode = 0x00;
+    // cfg.clipStatus = 0x00;
+    // cfg.conductionNum = 20;
+    // cfg.resistanceNum = 0;
+    // slave_cfg_msg.slaves.push_back(cfg);
+    // slave_cfg_msg.slaveNum = 2;
+    // auto msg = PacketPacker::backend2MasterPack(slave_cfg_msg);
+    // std::vector<uint8_t> data = FramePacker::pack(msg);
+    // Log.r(data.data(), data.size());
 
-    Log.i("[Master_Task]: Mode packet:");
-    Backend2Master::ModeCfgMsg mode_msg;
-    mode_msg.mode = 0x00;
-    msg = PacketPacker::backend2MasterPack(mode_msg);
-    data = FramePacker::pack(msg);
-    Log.r(data.data(), data.size());
+    // Log.i("[Master_Task]: Mode packet:");
+    // Backend2Master::ModeCfgMsg mode_msg;
+    // mode_msg.mode = 0x00;
+    // msg = PacketPacker::backend2MasterPack(mode_msg);
+    // data = FramePacker::pack(msg);
+    // Log.r(data.data(), data.size());
 
-    Log.i("[Master_Task]: Control start packet:");
-    Backend2Master::CtrlMsg ctrl_msg;
-    ctrl_msg.runningStatus = 0x01;
-    msg = PacketPacker::backend2MasterPack(ctrl_msg);
-    data = FramePacker::pack(msg);
-    Log.r(data.data(), data.size());
+    // Log.i("[Master_Task]: Control start packet:");
+    // Backend2Master::CtrlMsg ctrl_msg;
+    // ctrl_msg.runningStatus = 0x01;
+    // msg = PacketPacker::backend2MasterPack(ctrl_msg);
+    // data = FramePacker::pack(msg);
+    // Log.r(data.data(), data.size());
     
-    Log.i("[Master_Task]: Control stop packet:");
-    ctrl_msg.runningStatus = 0x00;
-    msg = PacketPacker::backend2MasterPack(ctrl_msg);
-    data = FramePacker::pack(msg);
-    Log.r(data.data(), data.size());
+    // Log.i("[Master_Task]: Control stop packet:");
+    // ctrl_msg.runningStatus = 0x00;
+    // msg = PacketPacker::backend2MasterPack(ctrl_msg);
+    // data = FramePacker::pack(msg);
+    // Log.r(data.data(), data.size());
 
 
     // 上位机数据传输任务 json解析任务 初始化

--- a/Source/Core/master/slave_manager.hpp
+++ b/Source/Core/master/slave_manager.hpp
@@ -112,9 +112,9 @@ class __ProcessBase {
             // 处理接收到的数据
             rsp_data.push_back(data);
         }
-        for (auto it : rsp_data) {
-            Log.d("[SlaveManager]: rx_data: 0x%02X", it);
-        }
+        // for (auto it : rsp_data) {
+        //     Log.d("[SlaveManager]: rx_data: 0x%02X", it);
+        // }
         // 解析数据
         auto msg = frame_parser.parse(rsp_data);
         if (msg != nullptr) {
@@ -155,14 +155,14 @@ class DeviceConfigProcessor : private __ProcessBase {
             Log.i("[SlaveManager]: cond config success");
         }
 
-        if (cfg_cmd.clip_exist) {
-            if (!__clip_config(cfg_cmd)) {
-                Log.e("[SlaveManager]: clip config failed");
-                ret = false;
-            }
-        } else {
-            Log.i("[SlaveManager]: clip config success");
-        }
+        // if (cfg_cmd.clip_exist) {
+        //     if (!__clip_config(cfg_cmd)) {
+        //         Log.e("[SlaveManager]: clip config failed");
+        //         ret = false;
+        //     }
+        // } else {
+        //     Log.i("[SlaveManager]: clip config success");
+        // }
         return ret;
     }
 
@@ -258,7 +258,7 @@ class DeviceCtrlProcessor : private __ProcessBase {
         sync_msg.timestamp = 0;
         ctrl = ctrl_cmd.ctrl;
         // 打包数据
-        auto sync_packet = PacketPacker::master2SlavePack(sync_msg, 0);
+        auto sync_packet = PacketPacker::master2SlavePack(sync_msg, 0xFFFFFFFF);
         sync_frame = FramePacker::pack(sync_packet);
 
         return true;

--- a/Source/Core/master/slave_manager.hpp
+++ b/Source/Core/master/slave_manager.hpp
@@ -187,7 +187,7 @@ class DeviceConfigProcessor : private __ProcessBase {
         // 打包数据
         uint32_t target_id = get_id(cfg_cmd.id);
         auto cond_packet =
-            PacketPacker::masterPack(wirte_cond_info_msg, target_id);
+            PacketPacker::master2SlavePack(wirte_cond_info_msg, target_id);
         auto cond_frame = FramePacker::pack(cond_packet);
 
         // 设置预期回复消息ID
@@ -206,7 +206,7 @@ class DeviceConfigProcessor : private __ProcessBase {
         // 打包数据
         uint32_t target_id = get_id(cfg_cmd.id);
         auto clip_packet =
-            PacketPacker::masterPack(write_clip_info_msg, target_id);
+            PacketPacker::master2SlavePack(write_clip_info_msg, target_id);
         auto clip_frame = FramePacker::pack(clip_packet);
 
         // 设置预期回复消息ID
@@ -258,7 +258,7 @@ class DeviceCtrlProcessor : private __ProcessBase {
         sync_msg.timestamp = 0;
         ctrl = ctrl_cmd.ctrl;
         // 打包数据
-        auto sync_packet = PacketPacker::masterPack(sync_msg, 0);
+        auto sync_packet = PacketPacker::master2SlavePack(sync_msg, 0);
         sync_frame = FramePacker::pack(sync_packet);
 
         return true;
@@ -298,7 +298,7 @@ class ReadCondProcessor : private __ProcessBase {
     bool process(uint32_t id) {
         Log.i("[SlaveManager]: read cond data start");
         // 打包数据
-        auto cond_packet = PacketPacker::masterPack(read_cond_data_msg, id);
+        auto cond_packet = PacketPacker::master2SlavePack(read_cond_data_msg, id);
         auto cond_frame = FramePacker::pack(cond_packet);
         expected_rsp_msg_id = (uint8_t)(Slave2BackendMessageID::COND_DATA_MSG);
         return send_frame(cond_frame);

--- a/Source/Core/protocol.hpp
+++ b/Source/Core/protocol.hpp
@@ -518,12 +518,12 @@ class CondCfgMsg : public Message {
     void serialize(std::vector<uint8_t>& data) const override {
         data.push_back(timeSlot);
         data.push_back(interval);    // 序列化采集间隔
-        data.push_back(static_cast<uint8_t>(totalConductionNum >> 8));
         data.push_back(static_cast<uint8_t>(totalConductionNum));
-        data.push_back(static_cast<uint8_t>(startConductionNum >> 8));
+        data.push_back(static_cast<uint8_t>(totalConductionNum >> 8));
         data.push_back(static_cast<uint8_t>(startConductionNum));
-        data.push_back(static_cast<uint8_t>(conductionNum >> 8));
+        data.push_back(static_cast<uint8_t>(startConductionNum >> 8));
         data.push_back(static_cast<uint8_t>(conductionNum));
+        data.push_back(static_cast<uint8_t>(conductionNum >> 8));
     }
 
     void deserialize(const std::vector<uint8_t>& data) override {
@@ -561,12 +561,12 @@ class ResCfgMsg : public Message {
     void serialize(std::vector<uint8_t>& data) const override {
         data.push_back(timeSlot);
         data.push_back(interval);    // 序列化采集间隔
-        data.push_back(static_cast<uint8_t>(totalResistanceNum >> 8));
         data.push_back(static_cast<uint8_t>(totalResistanceNum));
-        data.push_back(static_cast<uint8_t>(startResistanceNum >> 8));
+        data.push_back(static_cast<uint8_t>(totalResistanceNum >> 8));
         data.push_back(static_cast<uint8_t>(startResistanceNum));
-        data.push_back(static_cast<uint8_t>(resistanceNum >> 8));
+        data.push_back(static_cast<uint8_t>(startResistanceNum >> 8));
         data.push_back(static_cast<uint8_t>(resistanceNum));
+        data.push_back(static_cast<uint8_t>(resistanceNum >> 8));
     }
 
     void deserialize(const std::vector<uint8_t>& data) override {


### PR DESCRIPTION
将导通检测时间间隔从5调整为20
同步定时器冗余时间从0调整为100
移除调试用的Slave配置和日志打印代码
优化同步控制包的目标地址为广播模式(0xFFFFFFFF)

这些修改优化了系统检测时序并减少了不必要的调试输出