### PR TITLE
Cmake-modify

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,9 +15,4 @@
         "--query-driver=${env:ARM_CXX_PATH}"
     ],
     "todo-tree.tree.showBadges": false,
-    "marscode.chatLanguage": "cn",
-    "marscode.codeCompletionPro": {
-        "enableCodeCompletionPro": false
-    },
-    "marscode.enableInlineCommand": true,
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,27 +5,6 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 
-# Define the build type
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-# 定义可选构建变体
-set(BUILD_VARIANTS
-    "MASTER;SLAVE;DEMO"
-    CACHE STRING "Available build variants: MASTER, SLAVE, DEMO")
-set_property(CACHE BUILD_VARIANTS PROPERTY STRINGS MASTER SLAVE DEMO)
-
-# 设置默认变体
-if(NOT BUILD_VARIANT)
-  set(BUILD_VARIANT
-      "SLAVE"
-      CACHE STRING "Selected build variant")
-endif()
-
-# Include toolchain file
-include("CMake/arm-none-eabi-gcc.cmake")
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 enable_language(ASM C CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 # Setup compiler settings
 set(CMAKE_C_STANDARD 11)
@@ -10,6 +10,19 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+# 定义可选构建变体
+set(BUILD_VARIANTS
+    "MASTER;SLAVE;DEMO"
+    CACHE STRING "Available build variants: MASTER, SLAVE, DEMO")
+set_property(CACHE BUILD_VARIANTS PROPERTY STRINGS MASTER SLAVE DEMO)
+
+# 设置默认变体
+if(NOT BUILD_VARIANT)
+  set(BUILD_VARIANT
+      "SLAVE"
+      CACHE STRING "Selected build variant")
+endif()
+
 # Include toolchain file
 include("CMake/arm-none-eabi-gcc.cmake")
 
@@ -18,7 +31,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 enable_language(ASM C CXX)
 
 # 设置项目名称和版本号
-project(GD32_Clang_Cmake_template VERSION 0.1.0)
+project(wht VERSION 3.0.0)
 
 add_compile_options(
   -Wno-unused-parameter # 忽略未使用的参数警告

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+    "version": 3,
+    "configurePresets": [
+      {
+        "name": "master",
+        "displayName": "Master Edition",
+        "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
+        "generator": "Ninja",
+        "cacheVariables": {
+          "BUILD_VARIANT": "MASTER"
+        }
+      },
+      {
+        "name": "slave",
+        "displayName": "Slave Edition",
+        "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
+        "generator": "Ninja",
+        "cacheVariables": {
+          "BUILD_VARIANT": "SLAVE"
+        }
+      }
+    ]
+  }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,23 +1,46 @@
 {
     "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 19,
+        "patch": 0
+    },
     "configurePresets": [
-      {
-        "name": "master",
-        "displayName": "Master Edition",
-        "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
-        "generator": "Ninja",
-        "cacheVariables": {
-          "BUILD_VARIANT": "MASTER"
+        {
+            "name": "master",
+            "displayName": "Master Edition",
+            "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "true",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_VARIANT": "MASTER"
+            }
+        },
+        {
+            "name": "slave",
+            "displayName": "Slave Edition",
+            "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "true",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_VARIANT": "SLAVE"
+            }
+        },
+        {
+            "name": "demo",
+            "displayName": "Demo Edition",
+            "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "true",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_VARIANT": "DEMO"
+            }
         }
-      },
-      {
-        "name": "slave",
-        "displayName": "Slave Edition",
-        "toolchainFile": "${sourceDir}/CMake/arm-none-eabi-gcc.cmake",
-        "generator": "Ninja",
-        "cacheVariables": {
-          "BUILD_VARIANT": "SLAVE"
-        }
-      }
     ]
-  }
+}

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${EXECUTABLE_NAME} BSP Drivers freertos_kernel
 # ===============================================================================
 
 # 设置可执行文件的生成位置
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}/)
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/${BUILD_VARIANT}/${CMAKE_BUILD_TYPE}/)
 
 # 指定map文件生成路径
 target_link_options(

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -16,14 +16,26 @@ add_executable(${EXECUTABLE_NAME})
 include_directories(Config # 配置文件目录
 )
 
-if(BUILD_VARIANT STREQUAL "MASTER")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER GD32F470
-                                                        __cpluscplus)
-elseif(BUILD_VARIANT STREQUAL "SLAVE")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE GD32F470
-                                                        __cpluscplus)
+# 定义可选构建变体
+set(BUILD_VARIANT
+    "MASTER;SLAVE;DEMO"
+    CACHE STRING "Available build variants: MASTER, SLAVE, DEMO")
+set_property(CACHE BUILD_VARIANT PROPERTY STRINGS MASTER SLAVE DEMO)
 
+if(BUILD_VARIANT STREQUAL "MASTER")
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER
+                                                        BUILD_VARIANT=MASTER)
+elseif(BUILD_VARIANT STREQUAL "SLAVE")
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE
+                                                        BUILD_VARIANT=SLAVE)
+elseif(BUILD_VARIANT STREQUAL "DEMO")
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE DEMO BUILD_VARIANT=DEMO)
+else()
+  message(FATAL_ERROR "Unknown BUILD_VARIANT value: ${BUILD_VARIANT}")
 endif()
+
+# 添加公共宏
+target_compile_definitions(${EXECUTABLE_NAME} PRIVATE GD32F470)
 
 add_subdirectory(BSP)
 add_subdirectory(Core)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 # 使用字符串连接操作生成可执行文件的名称
 set(EXECUTABLE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}")
@@ -16,16 +16,13 @@ add_executable(${EXECUTABLE_NAME})
 include_directories(Config # 配置文件目录
 )
 
-# 定义选项（默认关闭）
-option(SLAVE "Build in slave mode" OFF)
-set(SLAVE ON) # 定义 SLAVE 并设为 ON
-
-if(SLAVE)
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE GD32F470
-                                                        __cpluscplus)
-else()
+if(BUILD_VARIANT STREQUAL "MASTER")
   target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER GD32F470
                                                         __cpluscplus)
+elseif(BUILD_VARIANT STREQUAL "SLAVE")
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE GD32F470
+                                                        __cpluscplus)
+
 endif()
 
 add_subdirectory(BSP)

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -1,15 +1,16 @@
 set(COMMON_SOURCES ./gd32f4xx_it.c ./main.cpp ./protocal.cpp)
 add_subdirectory(uwb)
-if(SLAVE)
+
+if(BUILD_VARIANT STREQUAL "MASTER")
+  target_sources(
+    ${EXECUTABLE_NAME} PRIVATE ${COMMON_SOURCES} ./master/master_mode.cpp
+                               ./master/pc_message.cpp)
+  target_include_directories(${EXECUTABLE_NAME} PUBLIC . ./master)
+elseif(BUILD_VARIANT STREQUAL "SLAVE")
   target_sources(
     ${EXECUTABLE_NAME}
     PRIVATE ${COMMON_SOURCES} ./slave/src/slave_mode.cpp
             ./slave/src/harness.cpp ./slave/src/msg_proc.cpp
             ./slave/src/peripherals.cpp)
   target_include_directories(${EXECUTABLE_NAME} PUBLIC . ./slave/inc)
-else()
-  target_sources(
-    ${EXECUTABLE_NAME} PRIVATE ${COMMON_SOURCES} ./master/master_mode.cpp
-                               ./master/pc_message.cpp)
-  target_include_directories(${EXECUTABLE_NAME} PUBLIC . ./master)
 endif()


### PR DESCRIPTION
将构建变体配置从CMakeLists.txt迁移到CMakePresets.json
添加DEMO构建变体支持并完善错误处理
统一构建目录和编译选项配置

移除了冗余的构建类型和工具链配置