### PR TITLE
[Feat] (Build): 自动从Git标签获取版本号并更新固件信息

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,18 +12,38 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 enable_language(ASM C CXX)
 
-# 设置项目名称和版本号
+# 获取 Git 标签作为版本号
+execute_process(
+  COMMAND git describe --tags --abbrev=0
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
+# 提取 MAJOR, MINOR, PATCH
+string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" VERSION_MATCH ${GIT_TAG})
+if(VERSION_MATCH)
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" PROJECT_VERSION_MAJOR ${VERSION_MATCH})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" PROJECT_VERSION_MINOR ${VERSION_MATCH})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\3" PROJECT_VERSION_PATCH ${VERSION_MATCH})
+else()
+  message(WARNING "Invalid git tag: ${GIT_TAG}, using default version 0.0.0")
+  set(PROJECT_VERSION_MAJOR 0)
+  set(PROJECT_VERSION_MINOR 0)
+  set(PROJECT_VERSION_PATCH 0)
+endif()
+
+# 设置项目名称和版本号（保留你的 BUILD_VARIANT 结构）
 if(BUILD_VARIANT STREQUAL "MASTER_DEBUG")
-  project(MasterFirmware VERSION 3.0.0)
+  project(MasterFirmware VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 elseif(BUILD_VARIANT STREQUAL "MASTER_RELEASE")
-  project(MasterFirmwareRelease VERSION 3.0.1)
+  project(MasterFirmwareRelease VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 elseif(BUILD_VARIANT STREQUAL "SLAVE_DEBUG")
-  project(SlaveFirmware VERSION 3.0.0)
+  project(SlaveFirmware VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 elseif(BUILD_VARIANT STREQUAL "SLAVE_RELEASE")
-  project(SlaveFirmwareRelease VERSION 3.0.0)
+  project(SlaveFirmwareRelease VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 elseif(BUILD_VARIANT STREQUAL "BOARDTEST")
-  project(BoardTestFirmware VERSION 3.1)
+  project(BoardTestFirmware VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 else()
   message(FATAL_ERROR "Unknown BUILD_VARIANT value: ${BUILD_VARIANT}")
 endif()

--- a/Source/BSP/src/bsp_uart.cpp
+++ b/Source/BSP/src/bsp_uart.cpp
@@ -81,7 +81,7 @@ UasrtInfo usart2_info = {.baudrate = 115200,
                          .rx_count = 0,
                          .dmaRxDoneSema = xSemaphoreCreateBinary()};
 
-UasrtInfo uart3_info = {.baudrate = 921600,
+UasrtInfo uart3_info = {.baudrate = 115200,
                         .gpio_port = GPIOA,
                         .tx_pin = GPIO_PIN_0,
                         .rx_pin = GPIO_PIN_1,

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -27,25 +27,25 @@ set_property(CACHE BUILD_VARIANT PROPERTY STRINGS MASTER MASTER_RELEASE SLAVE
                                           BOARDTEST)
 
 if(BUILD_VARIANT STREQUAL "MASTER_DEBUG")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER)
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER FIRMWARE_VERSION="v${PROJECT_VERSION}")
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -Og -g -DDEBUG
                                                     -funwind-tables)
 
 elseif(BUILD_VARIANT STREQUAL "MASTER_RELEASE")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER)
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE MASTER FIRMWARE_VERSION="v${PROJECT_VERSION}")
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -Os -DNDEBUG)
 
 elseif(BUILD_VARIANT STREQUAL "SLAVE_DEBUG")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE)
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE FIRMWARE_VERSION="v${PROJECT_VERSION}")
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -Og -g -DDEBUG
                                                     -funwind-tables)
 
 elseif(BUILD_VARIANT STREQUAL "SLAVE_RELEASE")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE)
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE SLAVE FIRMWARE_VERSION="v${PROJECT_VERSION}")
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -Os -DNDEBUG)
 
 elseif(BUILD_VARIANT STREQUAL "BOARDTEST")
-  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE BOARDTEST)
+  target_compile_definitions(${EXECUTABLE_NAME} PRIVATE BOARDTEST FIRMWARE_VERSION="v${PROJECT_VERSION}")
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -Og -g -DDEBUG
                                                     -funwind-tables)
 else()

--- a/Source/Core/master/master_mode.cpp
+++ b/Source/Core/master/master_mode.cpp
@@ -25,9 +25,11 @@ bool __ProcessBase::rsp_parsed = false;    // 从机回复正确标志位
 uint8_t __ProcessBase::expected_rsp_msg_id;    // 期望从机回复的消息ID
 
 static void Master_Task(void* pvParameters) {
+    static constexpr const char TAG[] = "BOOT";
     LED led(GPIO::Port::A, GPIO::Pin::PIN_0);
     LogTask logTask(Log);
     logTask.give();
+    Log.d(TAG, "LogTask initialized");
 
     // Backend2Master::SlaveCfgMsg slave_cfg_msg;
     // Backend2Master::SlaveCfgMsg::SlaveConfig cfg;
@@ -68,6 +70,8 @@ static void Master_Task(void* pvParameters) {
     // msg = PacketPacker::backend2MasterPack(ctrl_msg);
     // data = FramePacker::pack(msg);
     // Log.r(data.data(), data.size());
+
+    Log.d(TAG,"Slave Firmware %s, Build: %s %s", FIRMWARE_VERSION, __DATE__, __TIME__);
 
     EthDevice ethDevice;
     ethDevice.init();

--- a/Source/Core/slave/src/slave_mode.cpp
+++ b/Source/Core/slave/src/slave_mode.cpp
@@ -20,9 +20,9 @@ class MsgProcTask : public TaskClassS<MsgProcTask_SIZE> {
 
 static void Slave_Task(void* pvParameters) {
     static constexpr const char TAG[] = "BOOT";
-    Log.d(TAG, "Slave Device start");
+    Log.d(TAG,"Slave Firmware %s, Build: %s %s", FIRMWARE_VERSION, __DATE__, __TIME__);
     uint32_t myUid = UIDReader::get();
-    Log.d(TAG, "UID: %08X", myUid);
+    Log.d(TAG, "Slave UID: %08X", myUid);
 
     LogTask logTask(Log);
     logTask.give();


### PR DESCRIPTION
- 修改CMake构建系统从Git标签自动提取版本号（MAJOR.MINOR.PATCH）
- 统一所有构建变体的版本号来源，避免硬编码版本
- 降低UART3的波特率从921600到115200以提高稳定性
- 在固件启动日志中增加版本号、编译日期和时间信息
- 为从机设备日志添加更明确的标识前缀