### PR TITLE
chore(release): 移除不再需要的发布插件

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -3,8 +3,6 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer', // 分析 commit 类型
     '@semantic-release/release-notes-generator', // 自动生成 changelog
-    '@semantic-release/changelog',
-    '@semantic-release/git', // 提交 changelog 和版本号变更
     '@semantic-release/github' // 发布 GitHub Release
   ],
   preset: 'conventionalcommits',


### PR DESCRIPTION
移除了`@semantic-release/changelog`和`@semantic-release/git`插件， 这些插件在当前的发布流程中不再需要。
保留了核心的commit分析和GitHub发布功能。