### PR TITLE
fix(flash): 修复OpenOCD需要二次烧录的问题

### DIFF
--- a/CMake/flash_by_install.cmake
+++ b/CMake/flash_by_install.cmake
@@ -4,7 +4,7 @@ set(PYOCD_EXECUTABLE "pyocd")
 
 install(CODE
 CODE "MESSAGE(\"Flash......\")"
-CODE "execute_process(COMMAND ${OPENOCD_EXECUTABLE} -f ${PROJECT_SOURCE_DIR}/Scripts/OpenOCD/openocd_gdlink.cfg -c \"program ${EXECUTABLE_OUTPUT_PATH}/${EXECUTABLE_NAME}.elf verify reset\" -c shutdown)"
+CODE "execute_process(COMMAND ${OPENOCD_EXECUTABLE} -f ${PROJECT_SOURCE_DIR}/Scripts/OpenOCD/openocd_gdlink.cfg -c \"init; reset halt; program ${EXECUTABLE_OUTPUT_PATH}/${EXECUTABLE_NAME}.elf verify reset\" -c shutdown)"
 )
  
 # install(CODE


### PR DESCRIPTION
修改OpenOCD烧录命令，在烧录前添加init和reset halt指令
确保芯片正确初始化后再进行程序烧录操作

close 烧录异常，需要第二次才能正常烧录 #124
close #124 